### PR TITLE
Add Support for M5AtomEcho Microphone Audio

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,7 +1,7 @@
 {
     "configurations": [
         {
-            "name": "Mac",
+            "name": "ESP32",
             "includePath": [
                 "${workspaceFolder}/main/**",
                 "${workspaceFolder}/components/**"
@@ -11,7 +11,7 @@
                 "/System/Library/Frameworks",
                 "/Library/Frameworks"
             ],
-            "intelliSenseMode": "gcc-x64",
+            "intelliSenseMode": "gcc-arm",
             "compilerPath": "${env:IDF_TOOLS_PATH}/xtensa-esp32-elf-gcc",
             "cStandard": "c11",
             "cppStandard": "c++17",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,9 @@
     "ratio": "cpp",
     "system_error": "cpp",
     "tuple": "cpp",
-    "type_traits": "cpp"
+    "type_traits": "cpp",
+    "timer.h": "cpp",
+    "soulmateaudio.h": "cpp"
   },
   "files.exclude": {
     "components": false,

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [ "$(uname)" == "Darwin" ]; then
+if [[ "$(uname)" == "Darwin" ]]; then
     N_CORES=$(sysctl -n hw.ncpu)
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+elif [[ "$(expr substr $(uname -s) 1 5)" == "Linux" ]]; then
     N_CORES=$(nproc)
 fi
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(COMPONENT_SRCS "main.cpp")
+set(COMPONENT_SRCS "SoulmateAudio.cpp" "main.cpp")
 set(COMPONENT_ADD_INCLUDEDIRS ".")
 
 register_component()

--- a/main/SoulmateAudio.cpp
+++ b/main/SoulmateAudio.cpp
@@ -14,8 +14,13 @@
 #define MICROSECONDS_PER_S      (1000000)   
 #define WINDOW_PERIOD_US        (MICROSECONDS_PER_S / NUM_WINDOWS_PER_SECOND)  // Microseconds per sampling window
 
-static uint16_t audioOffset;
 static int16_t audioSamples[MIC_SAMPLE_FREQUENCY / NUM_WINDOWS_PER_SECOND];
+static audio_frame_t audioFrame = {
+    .frame_number = 0,
+    .sample_frequency = MIC_SAMPLE_FREQUENCY,
+    .num_samples = 0,
+    .samples = audioSamples,
+};
 
 // Disable all audio
 esp_err_t audioDisable(void)
@@ -30,8 +35,8 @@ esp_err_t audioEnableI2S(audio_mode_t mode)
         return err;
     }
 
-    // setup audio buffer
-    audioOffset = 0;
+    // setup audio frame
+    audioFrame.frame_number = 0;
     
     // configure i2s
     i2s_config_t i2s_config = {
@@ -79,7 +84,7 @@ esp_err_t audioDisableI2S(void)
     return i2s_driver_uninstall(SPEAKER_I2S_NUMBER);
 }
 
-static esp_err_t audioI2SUpdate(void)
+static esp_err_t audioUpdateI2S(void)
 {
     // check time since last update
     static int64_t last_update_time_us;
@@ -88,32 +93,26 @@ static esp_err_t audioI2SUpdate(void)
         return ESP_OK;
     }
     last_update_time_us = current_time_us;
-    
-    // Find out how many bytes to read
-    uint16_t buf_len = sizeof(audioSamples) / sizeof(audioSamples[0]);
-    uint16_t n_free_samples = buf_len - audioOffset;
-    uint16_t n_bytes_to_read = n_free_samples * sizeof(audioSamples[0]);
 
     // read bytes
     size_t bytes_read;
-    esp_err_t status = i2s_read(SPEAKER_I2S_NUMBER, (audioSamples + audioOffset), n_bytes_to_read, &bytes_read, 0);
-    audioOffset = (audioOffset + (bytes_read >> 1)) % buf_len;
+    esp_err_t status = i2s_read(SPEAKER_I2S_NUMBER, audioSamples, sizeof(audioSamples), &bytes_read, 0);
+    audioFrame.num_samples = bytes_read >> 1; // bytes_read >> log2(sizeof(audioSamples[0]))
+    audioFrame.frame_number++;
 
     return status;
 }
 
-int16_t* audioI2SSamples(int *n) {
+audio_frame_t* audioGetFrameI2S(void) {
     esp_err_t status = ESP_FAIL;
 
 #ifdef USE_MICROPHONE
-    status = audioI2SUpdate();
+    status = audioUpdateI2S();
 #endif
 
     if (status != ESP_OK) {
-        *n = 0;
         return NULL;
     }
 
-    *n = sizeof(audioSamples) / sizeof(audioSamples[0]);
-    return audioSamples;
+    return &audioFrame;
 }

--- a/main/SoulmateAudio.cpp
+++ b/main/SoulmateAudio.cpp
@@ -1,0 +1,118 @@
+#include "SoulmateAudio.h"
+
+#define CONFIG_I2S_BCK_PIN 19
+#define CONFIG_I2S_LRCK_PIN 33
+#define CONFIG_I2S_DATA_PIN 22
+#define CONFIG_I2S_DATA_IN_PIN 23
+
+#define SPEAKER_I2S_NUMBER I2S_NUM_0
+
+#define MIC_SAMPLE_FREQUENCY    16000   // Low samplerates not possible due to hardware requirements
+#define NUM_WINDOWS_PER_SECOND  50      // 20ms per window
+#define NUM_BUF_WINDOWS         2       // store N windows of audio
+
+typedef struct {
+    uint16_t offset;
+    uint16_t window_length;
+    uint8_t n_windows;
+    uint8_t n_windows_available;
+    int16_t *samples;
+} audio_buffer_t;
+
+static audio_buffer_t audioBuf;
+
+esp_err_t InitI2SAudio(audio_mode_t mode)
+{
+    esp_err_t err = i2s_driver_uninstall(SPEAKER_I2S_NUMBER);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    // setup audio buffer
+    audioBuf.offset = 0;
+    audioBuf.window_length = MIC_SAMPLE_FREQUENCY / NUM_WINDOWS_PER_SECOND; // 20ms
+    audioBuf.n_windows = NUM_BUF_WINDOWS;
+    audioBuf.n_windows_available = 0;
+    uint16_t buf_size = audioBuf.window_length * audioBuf.n_windows * sizeof(audioBuf.samples[0]);
+    if (audioBuf.samples != NULL) {
+        free(audioBuf.samples);
+    }
+    audioBuf.samples = (int16_t*)malloc(buf_size);
+    if (audioBuf.samples == NULL) {
+        return ESP_FAIL;
+    }
+    
+    // configure i2s
+    i2s_config_t i2s_config = {
+        .mode = (i2s_mode_t)(I2S_MODE_MASTER),
+        .sample_rate = MIC_SAMPLE_FREQUENCY,
+        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT, // is fixed at 12bit, stereo, MSB
+        .channel_format = I2S_CHANNEL_FMT_ALL_RIGHT,
+        .communication_format = I2S_COMM_FORMAT_I2S,
+        .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
+        .dma_buf_count = audioBuf.n_windows,
+        .dma_buf_len = audioBuf.window_length,
+        .use_apll = false,
+        .tx_desc_auto_clear = false,
+        .fixed_mclk = 0,
+    };
+
+    // Set i2s mode
+    if (mode == MODE_MIC) {
+        i2s_config.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM);
+    } else {
+        i2s_config.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX);
+        i2s_config.use_apll = false;
+        i2s_config.tx_desc_auto_clear = true;
+    }
+
+    err = i2s_driver_install(SPEAKER_I2S_NUMBER, &i2s_config, 0, NULL);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    i2s_pin_config_t tx_pin_config;
+    tx_pin_config.bck_io_num = CONFIG_I2S_BCK_PIN;
+    tx_pin_config.ws_io_num = CONFIG_I2S_LRCK_PIN;
+    tx_pin_config.data_out_num = CONFIG_I2S_DATA_PIN;
+    tx_pin_config.data_in_num = CONFIG_I2S_DATA_IN_PIN;
+
+    err += i2s_set_pin(SPEAKER_I2S_NUMBER, &tx_pin_config);
+    err += i2s_set_clk(SPEAKER_I2S_NUMBER, MIC_SAMPLE_FREQUENCY, I2S_BITS_PER_SAMPLE_16BIT, I2S_CHANNEL_MONO);
+
+    return err;
+}
+
+static void audioUpdate(void)
+{
+    // Find out how many bytes to read
+    uint16_t buf_len = audioBuf.window_length * audioBuf.n_windows;
+    uint16_t n_free_samples = buf_len - audioBuf.offset;
+    uint16_t n_bytes_to_read = (n_free_samples < audioBuf.window_length) ?
+        (n_free_samples * sizeof(audioBuf.samples[0])) :
+        (audioBuf.window_length * sizeof(audioBuf.samples[0]));
+
+    // read bytes
+    size_t bytes_read;
+    i2s_read(SPEAKER_I2S_NUMBER, (audioBuf.samples + audioBuf.offset), n_bytes_to_read, &bytes_read, 0);
+    audioBuf.offset = (audioBuf.offset + bytes_read) % buf_len;
+
+    // update n_windows_available
+    if (bytes_read > 0) {
+        Serial.printf("NumSaples: %d\n", bytes_read/2);
+        if (audioBuf.offset % audioBuf.window_length == 0) {    // complete window read
+            audioBuf.n_windows_available++;
+        } else if (audioBuf.n_windows_available == audioBuf.n_windows_available) { // partial window read with buffer overrun
+            audioBuf.n_windows_available--;
+        }
+
+        // complete window read with buffer overrun
+        if (audioBuf.n_windows_available > audioBuf.n_windows_available) {
+            audioBuf.n_windows_available = audioBuf.n_windows;
+        }
+    }
+}
+
+uint16_t audioAvailable(void) {
+    return audioBuf.n_windows_available * audioBuf.window_length;
+}

--- a/main/SoulmateAudio.h
+++ b/main/SoulmateAudio.h
@@ -17,6 +17,6 @@ esp_err_t audioDisable(void);
 // I2S Audio
 esp_err_t audioDisableI2S(void);
 esp_err_t audioEnableI2S(audio_mode_t mode);
-int audioI2SSamples(int16_t **samples);
+int16_t* audioI2SSamples(int *n);
 
 #endif /* soulmate_audio_h */

--- a/main/SoulmateAudio.h
+++ b/main/SoulmateAudio.h
@@ -11,12 +11,19 @@ typedef enum {
   MODE_SPK,
 } audio_mode_t;
 
+typedef struct {
+  uint32_t frame_number;
+  uint16_t sample_frequency;
+  uint16_t num_samples;
+  int16_t *samples;
+} audio_frame_t;
+
 // All audio
 esp_err_t audioDisable(void);
 
 // I2S Audio
 esp_err_t audioDisableI2S(void);
 esp_err_t audioEnableI2S(audio_mode_t mode);
-int16_t* audioI2SSamples(int *n);
+audio_frame_t* audioGetFrameI2S(void);
 
 #endif /* soulmate_audio_h */

--- a/main/SoulmateAudio.h
+++ b/main/SoulmateAudio.h
@@ -1,0 +1,17 @@
+#ifndef soulmate_audio_h
+#define soulmate_audio_h
+
+#include <Arduino.h>
+#include <Wire.h>
+#include "driver/i2s.h"
+#include "driver/timer.h"
+
+typedef enum {
+  MODE_MIC,
+  MODE_SPK,
+} audio_mode_t;
+
+uint16_t audioAvailable(void);
+esp_err_t InitI2SAudio(audio_mode_t mode);
+
+#endif /* soulmate_audio_h */

--- a/main/SoulmateAudio.h
+++ b/main/SoulmateAudio.h
@@ -11,7 +11,12 @@ typedef enum {
   MODE_SPK,
 } audio_mode_t;
 
-uint16_t audioAvailable(void);
-esp_err_t InitI2SAudio(audio_mode_t mode);
+// All audio
+esp_err_t audioDisable(void);
+
+// I2S Audio
+esp_err_t audioDisableI2S(void);
+esp_err_t audioEnableI2S(audio_mode_t mode);
+int audioI2SSamples(int16_t **samples);
 
 #endif /* soulmate_audio_h */

--- a/main/SoulmateMain.h
+++ b/main/SoulmateMain.h
@@ -233,8 +233,8 @@ public:
     BluetoothSetup();
 #endif
 
-#ifdef MIC_ENABLED
-    InitI2SAudio(MODE_MIC);
+#ifdef USE_MICROPHONE
+    audioEnableI2S(MODE_MIC);
 #endif
 
     Serial.println(status(true));

--- a/main/SoulmateMain.h
+++ b/main/SoulmateMain.h
@@ -10,6 +10,7 @@
 #define FASTLED_INTERRUPT_RETRY_COUNT 1
 #define FASTLED_INTERNAL
 
+#include "SoulmateAudio.h"
 #include "SoulmateBeatSin.h"
 #include "SoulmateCircadian.h"
 #include "SoulmateConfig.h"
@@ -230,6 +231,10 @@ public:
     WifiSetup();
 #ifndef SKIP_BLUETOOTH
     BluetoothSetup();
+#endif
+
+#ifdef MIC_ENABLED
+    InitI2SAudio(MODE_MIC);
 #endif
 
     Serial.println(status(true));

--- a/main/SoulmateMain.h
+++ b/main/SoulmateMain.h
@@ -207,6 +207,10 @@ public:
     if (savedRoutine && savedRoutine < routineCount)
       currentRoutine = savedRoutine;
 
+#ifdef USE_MICROPHONE
+    audioEnableI2S(MODE_MIC);
+#endif
+
 // Set up FastLED
 #ifdef USE_WS2812B
     FastLED.addLeds<WS2812B, SOULMATE_DATA_PIN, SOULMATE_COLOR_ORDER>(leds,
@@ -231,10 +235,6 @@ public:
     WifiSetup();
 #ifndef SKIP_BLUETOOTH
     BluetoothSetup();
-#endif
-
-#ifdef USE_MICROPHONE
-    audioEnableI2S(MODE_MIC);
 #endif
 
     Serial.println(status(true));

--- a/main/SoulmateMatrix.h
+++ b/main/SoulmateMatrix.h
@@ -132,8 +132,6 @@ int16_t gridIndex(int16_t x, int16_t y) {
 int16_t gridIndexHorizontal(uint8_t x, uint8_t y) {
   if (y > LED_ROWS) return -1;
   if (x > LED_COLS) return -1;
-  if (x < 0) return -1;
-  if (y < 0) return -1;
 
   int16_t xIndex = x;
 

--- a/main/component.mk
+++ b/main/component.mk
@@ -1,1 +1,2 @@
 CXXFLAGS += -Wall -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wno-error=parentheses -Wno-error=sizeof-pointer-memaccess -Wno-error=unused-value -Wno-error=type-limits -Wno-error=return-type -fpermissive -Wno-maybe-uninitialized
+CXXFLAGS += -DUSE_MICROPHONE # DO NOT MERGE!!!

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -11,6 +11,9 @@
 #define SOULMATE_SERPENTINE true
 // #define USE_WS2812B true
 
+// NOCHECKIN
+#define MIC_ENABLED
+
 #include "Soulmate.h"
 
 void pattern() {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -13,18 +13,19 @@
 #include "Soulmate.h"
 
 void pattern() { // DO NOT MERGE!!!
-  int nSamples;
-  int16_t *samples = audioI2SSamples(&nSamples);
-  if (samples == NULL) {
+  static uint32_t last_frame_num;
+  audio_frame_t *af = audioGetFrameI2S();
+  if (af->frame_number == last_frame_num) {
     return;
   }
+  last_frame_num = af->frame_number;
 
   CRGB *led;
   int16_t sample;
   for (int i = 0; i < N_LEDS; i++) {
     led = &Soulmate.leds[i];
     for (int j = 0; j < 3; j++) {
-      sample = samples[(3*i+j) % nSamples];
+      sample = af->samples[(3*i+j) % af->num_samples];
       if (sample < 0) {
         sample = -sample;
       }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -12,7 +12,7 @@
 // #define USE_WS2812B true
 
 // NOCHECKIN
-#define MIC_ENABLED
+#define USE_MICROPHONE
 
 #include "Soulmate.h"
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1,24 +1,41 @@
 #define FIRMWARE_NAME "soulmate"
-#define N_LEDS 196
-#define SOULMATE_MILLIAMPS 4000
-#define LED_TYPE SK9822
-// #define FADE_DURATION 10
-#define LED_COLS 14
-#define LED_ROWS 14
+#define SOULMATE_MILLIAMPS 3000
+#define FADE_DURATION 10
+#define LED_ROWS 8
+#define LED_COLS 8
+#define N_LEDS (LED_ROWS * LED_COLS)
 #define SOULMATE_DATA_PIN 32
 #define SOULMATE_CLOCK_PIN 26
 #define SOULMATE_BUTTON_PIN 39
 #define SOULMATE_SERPENTINE true
-// #define USE_WS2812B true
-
-// NOCHECKIN
-#define USE_MICROPHONE
+#define USE_WS2812B true
 
 #include "Soulmate.h"
 
-void pattern() {
+void pattern() { // DO NOT MERGE!!!
+  int nSamples;
+  int16_t *samples = audioI2SSamples(&nSamples);
+  if (samples == NULL) {
+    return;
+  }
+
+  CRGB *led;
+  int16_t sample;
   for (int i = 0; i < N_LEDS; i++) {
-    Soulmate.leds[i] = CRGB::Red;
+    led = &Soulmate.leds[i];
+    for (int j = 0; j < 3; j++) {
+      sample = samples[(3*i+j) % nSamples];
+      if (sample < 0) {
+        sample = -sample;
+      }
+      
+      sample >>= 1;
+      if (sample > 255) {
+        sample = 255;
+      }
+      
+      led->raw[j] = sample;
+    }
   }
 }
 


### PR DESCRIPTION
This branch adds support for the M5AtomEcho Microphone through a new library called SoulmateAudio. Things that need to be done before merging:
- [x] Make audio works and frames are accessible from within patterns
- [ ] Make sure OTA updates still work
- [ ] Add Flag to IDE for new hardware? Or run audio task on all M5Atom hardware?
- [ ] Format SoulmateAudio library to match others (namespaces, etc.)
- [ ] Restore main.cpp defines to default values
- [ ] Remove all debug code (pattern() in main.cpp, CXX_FLAGS in main/component.mk)